### PR TITLE
Fix available and size counter for non-recycled objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.5.2-issue92
+
+* Fix invalid `size` and `available` counts when recycling fails
+
 ## v0.5.2
 
 * Deprecate `managed::Config::from_env`

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -260,7 +260,11 @@ impl<T, E> Pool<T, E> {
                     .await?
                     {
                         Ok(_) => break,
-                        Err(_) => continue,
+                        Err(_) => {
+                            self.inner.available.fetch_sub(1, Ordering::Relaxed);
+                            self.inner.size.fetch_sub(1, Ordering::Relaxed);
+                            continue;
+                        },
                     }
                 }
                 Err(_) => {

--- a/tests/managed_unreliable_manager.rs
+++ b/tests/managed_unreliable_manager.rs
@@ -67,14 +67,21 @@ mod tests {
         };
         let pool = Pool::new(manager, 16);
         {
-            assert_eq!(pool.get().await.is_ok(), true);
+            let _a = pool.get().await.unwrap();
+            let _b = pool.get().await.unwrap();
         }
         let status = pool.status();
-        assert_eq!(status.available, 1);
-        assert_eq!(status.size, 1);
+        assert_eq!(status.available, 2);
+        assert_eq!(status.size, 2);
         {
-            assert_eq!(pool.get().await.is_ok(), true);
+            let _a = pool.get().await.unwrap();
+            // All connections fail to recycle. Thus reducing the
+            // available counter to 0.
+            let status = pool.status();
+            assert_eq!(status.available, 0);
+            assert_eq!(status.size, 1);
         }
+        let status = pool.status();
         assert_eq!(status.available, 1);
         assert_eq!(status.size, 1);
     }


### PR DESCRIPTION
This fixes #93

(cherry picked from commit 15f94710a7e653941924379ae66fb2371a6946ee)

NOTE: this does indeed fix [#92](https://github.com/bikeshedder/deadpool/issues/92), upstream typo'd this commit message